### PR TITLE
Restrict User Profile Privileges 

### DIFF
--- a/Client/src/components/ApplicationViews.jsx
+++ b/Client/src/components/ApplicationViews.jsx
@@ -34,7 +34,7 @@ export default function ApplicationViews({ loggedInUser, setLoggedInUser }) {
             index
             element={
               <AuthorizedRoute loggedInUser={loggedInUser}>
-                <ExplorePosts />
+                <ExplorePosts loggedInUser={loggedInUser} />
               </AuthorizedRoute>
             }
           />
@@ -73,7 +73,7 @@ export default function ApplicationViews({ loggedInUser, setLoggedInUser }) {
           <Route
             path="manage"
             element={
-              <AuthorizedRoute loggedInUser={loggedInUser}>
+              <AuthorizedRoute loggedInUser={loggedInUser} roles={["Admin"]}>
                 <ManagePosts />
               </AuthorizedRoute>
             }

--- a/Client/src/components/comments/CommentList.jsx
+++ b/Client/src/components/comments/CommentList.jsx
@@ -178,7 +178,8 @@ export default function CommentList({ loggedInUser, postId }) {
                   >
                     {c.body}
                   </p>
-                  {c.userProfileId === loggedInUser.id && (
+                  {(c.userProfileId === loggedInUser.id ||
+                    loggedInUser.roles?.includes("Admin")) && (
                     <div className="d-flex gap-2 ms-3">
                       <button
                         className="border rounded"

--- a/Client/src/components/posts/ExplorePosts.jsx
+++ b/Client/src/components/posts/ExplorePosts.jsx
@@ -1,31 +1,41 @@
 import { useEffect, useState } from "react";
 import {
+  deletePost,
   getAllPosts,
   getPostsByCategoryId,
   getTagCatFilteredPosts,
 } from "../../managers/postManager";
 import { getTags } from "../../managers/tagManager";
 import {
+  Button,
   Card,
   CardBody,
   CardSubtitle,
   CardText,
   CardTitle,
   Col,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
   Row,
 } from "reactstrap";
 import { useNavigate } from "react-router-dom";
 import "../../styles/tags.css";
 import "../../styles/posts.css";
 import CategoryDropdownFilter from "../category/CategoryDropdownFilter";
-export const ExplorePosts = () => {
+export const ExplorePosts = ({ loggedInUser }) => {
   const [allPosts, setAllPosts] = useState([]);
   const [filteredPosts, setFilteredPosts] = useState([]);
   const [tags, setTags] = useState([]);
   const [selectedTagId, setSelectedTagId] = useState(0);
   const [selectedCategoryId, setSelectedCategoryId] = useState(0);
+  const [modal, setModal] = useState(false);
+  const [modalTarget, setModalTarget] = useState({});
 
   const navigate = useNavigate();
+
+  const toggle = () => setModal(!modal);
 
   useEffect(() => {
     getAllPosts().then(setAllPosts);
@@ -66,6 +76,16 @@ export const ExplorePosts = () => {
 
     fetchPosts();
   }, [selectedCategoryId, selectedTagId]);
+
+  const handleDeletePost = (postId) => {
+    deletePost(postId)
+      .then(() => getAllPosts())
+      .then((posts) => {
+        setAllPosts(posts);
+        setFilteredPosts(posts);
+        return posts;
+      });
+  };
 
   return (
     <div className="container mt-5">
@@ -152,6 +172,19 @@ export const ExplorePosts = () => {
                       <CardText className="text-muted">{`Read Time: ${handleReadTimeCalc(
                         p.body
                       )}`}</CardText>
+                      {(loggedInUser.roles?.includes("Admin") ||
+                        p.userProfileId === parseInt(loggedInUser.id)) && (
+                        <Button
+                          className="my-post-delete"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setModalTarget(p);
+                            toggle();
+                          }}
+                        >
+                          Delete Post
+                        </Button>
+                      )}
                     </Col>
                   </Row>
                 </CardBody>
@@ -160,6 +193,26 @@ export const ExplorePosts = () => {
           ))}
         </Col>
       </Row>
+      <Modal isOpen={modal} toggle={toggle}>
+        <ModalHeader toggle={toggle}>
+          {`Delete ${modalTarget.title}?`}
+        </ModalHeader>
+        <ModalBody>Are you sure you want to delete this post?</ModalBody>
+        <ModalFooter>
+          <Button
+            className="my-post-delete"
+            onClick={() => {
+              handleDeletePost(modalTarget.id);
+              toggle();
+            }}
+          >
+            Delete
+          </Button>
+          <Button className="my-post-edit" onClick={toggle}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
     </div>
   );
 };

--- a/Controllers/CategoryController.cs
+++ b/Controllers/CategoryController.cs
@@ -31,7 +31,7 @@ public class CategoryController : ControllerBase
     }
 
     [HttpPost]
-    [Authorize]
+    [Authorize (Roles = "Admin")]
     public IActionResult CreateCategory(CreateCategoryDTO categoryDTO)
     {
         var category = new Category { CategoryName = categoryDTO.CategoryName };
@@ -42,7 +42,7 @@ public class CategoryController : ControllerBase
     }
 
     [HttpPut("{id}")]
-    [Authorize]
+    [Authorize (Roles = "Admin")]
     public IActionResult UpdateCategory(CreateCategoryDTO categoryDTO, int id)
     {
         Category categoryToUpdate = _dbContext.Categories.SingleOrDefault(c => c.Id == id);
@@ -60,7 +60,7 @@ public class CategoryController : ControllerBase
     }
 
     [HttpDelete("{id}")]
-    [Authorize]
+    [Authorize (Roles = "Admin")]
     public IActionResult DeleteCategory(int id)
     {
         Category categoryToDelete = _dbContext.Categories.SingleOrDefault(c => c.Id == id);

--- a/Controllers/PostController.cs
+++ b/Controllers/PostController.cs
@@ -479,7 +479,7 @@ public class PostController : ControllerBase
     }
 
     [HttpPut("{id}/approval")]
-    [Authorize]
+    [Authorize (Roles = "Admin")]
     public IActionResult ToggleApproval(int id)
     {
         try

--- a/Controllers/PostTagController.cs
+++ b/Controllers/PostTagController.cs
@@ -17,7 +17,7 @@ public class PostTagController : ControllerBase
 
     [HttpPost]
     [Authorize]
-    public IActionResult NewPostTag([FromBody] PostTag postTag) //Need to add a way to prevent posting a PostTag if that relationship already exists
+    public IActionResult NewPostTag([FromBody] PostTag postTag) 
     {
         try 
         {

--- a/Controllers/ReactionController.cs
+++ b/Controllers/ReactionController.cs
@@ -39,7 +39,7 @@ public class ReactionController : ControllerBase
     }
 
     [HttpPost]
-    [Authorize]
+    [Authorize(Roles = "Admin")]
     public IActionResult PostReaction(CreateReactionDTO createReactionDTO)
     {
         Reaction reactionToAdd = new Reaction

--- a/Controllers/TagController.cs
+++ b/Controllers/TagController.cs
@@ -72,7 +72,7 @@ public class TagController : ControllerBase
     }
 
     [HttpPut("{id}")]
-    [Authorize]
+    [Authorize (Roles = "Admin")]
 
     public IActionResult Put(int id, EditTagDTO tag)
     {
@@ -96,6 +96,7 @@ public class TagController : ControllerBase
     }
 
     [HttpPost]
+    [Authorize(Roles = "Admin")]
     public IActionResult Post(Tag tag)
     {
         _dbContext.Tags.Add(tag);
@@ -104,7 +105,7 @@ public class TagController : ControllerBase
     }
 
     [HttpDelete("{id}")]
-    
+    [Authorize(Roles = "Admin")]
     public IActionResult Delete(int id)
     {
         var tag = _dbContext.Tags.SingleOrDefault(t => t.Id == id);


### PR DESCRIPTION


Related Issue:
relates NSS-Day-Cohort-73/Tabloid-client-uakfwy#3
relates NSS-Day-Cohort-73/Tabloid-client-uakfwy#5
relates NSS-Day-Cohort-73/Tabloid-client-uakfwy#16
relates NSS-Day-Cohort-73/Tabloid-client-uakfwy#14
relates NSS-Day-Cohort-73/Tabloid-client-uakfwy#21
relates NSS-Day-Cohort-73/Tabloid-client-uakfwy#11
relates NSS-Day-Cohort-73/Tabloid-client-uakfwy#10
relates NSS-Day-Cohort-73/Tabloid-client-uakfwy#38

Changes:
Added Admin role authentication to Post/Edit/Delete a Tag, Edit/Create Category, Create Reaction endpoints
Added Admin Role authentication to ManagePosts component call in ApplicationViews
Created a button to conditionally render on explore page posts if logged in user is an admin or wrote the post
Added logic to comment deletion to allow admins to delete and comment 
Readme Info:

- [ ] required packages (new)
- [ ] API instructions

Any other Testing Steps:
Be logged in as an Admin and try to delete a post from Explore page, then try again as an author
attempt to access endpoints to edit or delete a tag, reaction, or category as a non-admin user
attempt to delete any comment in a posts details as ana dmin user vs a non-admin user
attempt to access manage posts view as a non admin user
closes NSS-Day-Cohort-73/Tabloid-client-uakfwy#33
