### PR TITLE
45 two admins to deactivate or demote

### DIFF
--- a/Client/src/components/userprofiles/UserProfileDetails.jsx
+++ b/Client/src/components/userprofiles/UserProfileDetails.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import {
-  demoteUser,
+  //demoteUser,
   getProfile,
   promoteUser,
 } from "../../managers/userProfileManager";
@@ -18,6 +18,7 @@ export default function UserProfileDetails({ loggedInUser }) {
 
   const handleUpdateUserRole = (userProfile) => {
     if (userProfile.roles?.includes("Admin")) {
+      //This is another if statement to check if this user has any votes
       demoteUser(userProfile.identityUserId)
         .then(() => getProfile(id))
         .then(setUserProfile);

--- a/Client/src/components/userprofiles/UserProfileDetails.jsx
+++ b/Client/src/components/userprofiles/UserProfileDetails.jsx
@@ -3,12 +3,17 @@ import { useParams } from "react-router-dom";
 import {
   //demoteUser,
   getProfile,
+  getUserPendingAction,
+  initializeDemote,
   promoteUser,
+  voteToDemote,
 } from "../../managers/userProfileManager";
 import { Button } from "reactstrap";
 
 export default function UserProfileDetails({ loggedInUser }) {
   const [userProfile, setUserProfile] = useState();
+  const [pendingActions, setPendingActions] = useState([]);
+  const [currentUserAction, setCurrentUserAction] = useState({ id: 0 });
 
   const { id } = useParams();
 
@@ -16,12 +21,24 @@ export default function UserProfileDetails({ loggedInUser }) {
     getProfile(id).then(setUserProfile);
   }, [id]);
 
+  useEffect(() => {
+    getUserPendingAction(id).then(setPendingActions);
+  }, [pendingActions.length]);
+
   const handleUpdateUserRole = (userProfile) => {
     if (userProfile.roles?.includes("Admin")) {
-      //This is another if statement to check if this user has any votes
-      demoteUser(userProfile.identityUserId)
-        .then(() => getProfile(id))
-        .then(setUserProfile);
+      if (currentUserAction.id === 0) {
+        initializeDemote(userProfile.identityUserId, loggedInUser.id)
+          .then((response) => {
+            setCurrentUserAction(response);
+          })
+          .then(() => getProfile(id))
+          .then(setUserProfile);
+      } else {
+        voteToDemote(currentUserAction.id, loggedInUser.id)
+          .then(() => getProfile(id))
+          .then(setUserProfile);
+      }
     } else {
       promoteUser(userProfile.identityUserId)
         .then(() => getProfile(id))
@@ -35,14 +52,18 @@ export default function UserProfileDetails({ loggedInUser }) {
       loggedInUser.roles?.includes("Admin")
     ) {
       if (userProfile.roles?.includes("Admin")) {
-        return (
-          <Button
-            className="my-post-delete"
-            onClick={() => handleUpdateUserRole(userProfile)}
-          >
-            Demote
-          </Button>
-        );
+        if (currentUserAction.id === 0) {
+          return (
+            <Button
+              className="my-post-delete"
+              onClick={() => handleUpdateUserRole(userProfile)}
+            >
+              Demote
+            </Button>
+          );
+        } else if (currentUserAction.id !== 0) {
+          return <Button className="my-post-delete">Vote To Demote</Button>;
+        }
       } else {
         return (
           <Button

--- a/Client/src/components/userprofiles/UserProfileDetails.jsx
+++ b/Client/src/components/userprofiles/UserProfileDetails.jsx
@@ -1,18 +1,19 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import {
-  //demoteUser,
   getProfile,
   getUserPendingAction,
   initializeDemote,
   promoteUser,
   voteToDemote,
 } from "../../managers/userProfileManager";
-import { Button } from "reactstrap";
+import { Alert, Button } from "reactstrap";
 
 export default function UserProfileDetails({ loggedInUser }) {
   const [userProfile, setUserProfile] = useState();
-  const [pendingActions, setPendingActions] = useState([]);
+  const [pendingActions, setPendingActions] = useState({});
+  const [showAlert, setShowAlert] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
 
   const { id } = useParams();
 
@@ -21,27 +22,45 @@ export default function UserProfileDetails({ loggedInUser }) {
   }, [id]);
 
   useEffect(() => {
-    getUserPendingAction(id).then(setPendingActions);
+    const fetchPendingActions = async () => {
+      const data = await getUserPendingAction(id);
+      console.log("Initial pending actions:", data);
+      setPendingActions(data);
+    };
+    fetchPendingActions();
   }, [id]);
 
-  const handleUpdateUserRole = (userProfile) => {
+  const handleUpdateUserRole = async (userProfile) => {
     if (userProfile.roles?.includes("Admin")) {
-      if (pendingActions.length === 0) {
-        initializeDemote(userProfile.identityUserId, loggedInUser.id)
-          .then((response) => {
-            setCurrentUserAction(response);
-          })
-          .then(() => getProfile(id))
-          .then(setUserProfile);
+      if (Object.keys(pendingActions).length === 0) {
+        await initializeDemote(userProfile.identityUserId, loggedInUser.id);
+        const updatedProfile = await getProfile(id);
+        setUserProfile(updatedProfile);
+
+        const newPendingAction = await getUserPendingAction(id);
+        setPendingActions(newPendingAction);
       } else {
-        voteToDemote(pendingActions.id, loggedInUser.id)
-          .then(() => getProfile(id))
-          .then(setUserProfile);
+        const voteResponse = await voteToDemote(
+          pendingActions.id,
+          loggedInUser.id
+        );
+        if (voteResponse.error) {
+          setShowAlert(true);
+          setErrorMessage(voteResponse.error);
+        }
+        const updatedProfile = await getProfile(id);
+        setUserProfile(updatedProfile);
+
+        const updatedPendingActions = await getUserPendingAction(id);
+        setPendingActions(updatedPendingActions);
       }
     } else {
       promoteUser(userProfile.identityUserId)
         .then(() => getProfile(id))
-        .then(setUserProfile);
+        .then(setUserProfile)
+        .then(() => {
+          setPendingActions({});
+        });
     }
   };
 
@@ -51,7 +70,7 @@ export default function UserProfileDetails({ loggedInUser }) {
       loggedInUser.roles?.includes("Admin")
     ) {
       if (userProfile.roles?.includes("Admin")) {
-        if (pendingActions.length === 0) {
+        if (Object.keys(pendingActions).length === 0) {
           return (
             <Button
               className="my-post-delete"
@@ -60,7 +79,7 @@ export default function UserProfileDetails({ loggedInUser }) {
               Demote
             </Button>
           );
-        } else if (pendingActions.length !== 0) {
+        } else {
           return (
             <Button
               className="my-post-delete"
@@ -133,6 +152,7 @@ export default function UserProfileDetails({ loggedInUser }) {
               </p>
             </div>
             {renderPromoteDemoteButton()}
+            {showAlert ? <Alert className="mt-3">{errorMessage}</Alert> : ""}
           </div>
         </div>
       </div>

--- a/Client/src/components/userprofiles/UserProfileDetails.jsx
+++ b/Client/src/components/userprofiles/UserProfileDetails.jsx
@@ -13,7 +13,6 @@ import { Button } from "reactstrap";
 export default function UserProfileDetails({ loggedInUser }) {
   const [userProfile, setUserProfile] = useState();
   const [pendingActions, setPendingActions] = useState([]);
-  const [currentUserAction, setCurrentUserAction] = useState({ id: 0 });
 
   const { id } = useParams();
 
@@ -23,11 +22,11 @@ export default function UserProfileDetails({ loggedInUser }) {
 
   useEffect(() => {
     getUserPendingAction(id).then(setPendingActions);
-  }, [pendingActions.length]);
+  }, [id]);
 
   const handleUpdateUserRole = (userProfile) => {
     if (userProfile.roles?.includes("Admin")) {
-      if (currentUserAction.id === 0) {
+      if (pendingActions.length === 0) {
         initializeDemote(userProfile.identityUserId, loggedInUser.id)
           .then((response) => {
             setCurrentUserAction(response);
@@ -35,7 +34,7 @@ export default function UserProfileDetails({ loggedInUser }) {
           .then(() => getProfile(id))
           .then(setUserProfile);
       } else {
-        voteToDemote(currentUserAction.id, loggedInUser.id)
+        voteToDemote(pendingActions.id, loggedInUser.id)
           .then(() => getProfile(id))
           .then(setUserProfile);
       }
@@ -52,7 +51,7 @@ export default function UserProfileDetails({ loggedInUser }) {
       loggedInUser.roles?.includes("Admin")
     ) {
       if (userProfile.roles?.includes("Admin")) {
-        if (currentUserAction.id === 0) {
+        if (pendingActions.length === 0) {
           return (
             <Button
               className="my-post-delete"
@@ -61,8 +60,15 @@ export default function UserProfileDetails({ loggedInUser }) {
               Demote
             </Button>
           );
-        } else if (currentUserAction.id !== 0) {
-          return <Button className="my-post-delete">Vote To Demote</Button>;
+        } else if (pendingActions.length !== 0) {
+          return (
+            <Button
+              className="my-post-delete"
+              onClick={() => handleUpdateUserRole(userProfile)}
+            >
+              Vote To Demote
+            </Button>
+          );
         }
       } else {
         return (

--- a/Client/src/managers/userProfileManager.js
+++ b/Client/src/managers/userProfileManager.js
@@ -31,16 +31,59 @@ export const promoteUser = async (identityUserId) => {
   }
 };
 
-export const demoteUser = async (identityUserId) => {
-  const response = await fetch(`${_apiUrl}/demote/${identityUserId}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
+//Gets Pending Actions for a target User
+//Expects a UserId
+export const getUserPendingAction = async (userId) => {
+  const response = await fetch(`${_apiUrl}/pending/${userId}`);
+
   if (!response.ok) {
     throw new Error(`HTTP Error! Status ${response.status}`);
   }
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  return response.json();
 };
 
-export const adminActions
+//Initializes an Admin Action to demote a user.
+//Expects the Identity User Id of the user being demoted, as well as the UserId of the user initializing the action
+export const initializeDemote = async (identityUserId, currentUserId) => {
+  const response = await fetch(
+    `${_apiUrl}/demote/${identityUserId}?currentUserId=${currentUserId}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+  if (!response.ok) {
+    throw new Error(`HTTP Error! Status ${response.status}`);
+  }
+
+  return response.json();
+};
+
+//Creates a new vote on an existing Demote Action.
+//Expects the Id of the action that is being voted on, as well as the UserId of the user placing the vote
+export const voteToDemote = async (actionId, currentUserId) => {
+  const response = await fetch(
+    `${_apiUrl}/demote/vote/${actionId}?currentUserId=${currentUserId}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+  if (!response.ok) {
+    throw new Error(`HTTP Error! Status ${response.status}`);
+  }
+  if (response.status === 204) {
+    return { message: "User has been demoted" };
+  }
+
+  return response.json();
+};

--- a/Client/src/managers/userProfileManager.js
+++ b/Client/src/managers/userProfileManager.js
@@ -43,8 +43,12 @@ export const getUserPendingAction = async (userId) => {
   if (response.status === 404) {
     return null;
   }
+  const data = response.json();
+  // if (!data || Object.keys(data).length === 0) {
+  //   return null;
+  // }
 
-  return response.json();
+  return data;
 };
 
 //Initializes an Admin Action to demote a user.
@@ -79,7 +83,15 @@ export const voteToDemote = async (actionId, currentUserId) => {
     }
   );
   if (!response.ok) {
-    throw new Error(`HTTP Error! Status ${response.status}`);
+    let errorMessage = `HTTP Error! Status ${response.status}`;
+
+    try {
+      const errorData = await response.text();
+      errorMessage = errorData || errorMessage;
+    } catch (error) {
+      console.error("Failed to parse error response", error);
+    }
+    return { error: errorMessage };
   }
   if (response.status === 204) {
     return { message: "User has been demoted" };

--- a/Client/src/managers/userProfileManager.js
+++ b/Client/src/managers/userProfileManager.js
@@ -42,3 +42,5 @@ export const demoteUser = async (identityUserId) => {
     throw new Error(`HTTP Error! Status ${response.status}`);
   }
 };
+
+export const adminActions

--- a/Controllers/UserProfileController.cs
+++ b/Controllers/UserProfileController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Tabloid.Data;
 using Tabloid.Models;
+using Tabloid.Models.DTOs;
 
 namespace Tabloid.Controllers;
 
@@ -77,14 +78,22 @@ public class UserProfileController : ControllerBase
     public IActionResult InitializeDemotion(string id, [FromQuery, Required] int currentUserId)
     {
 
-        UserProfile currentUser = _dbContext.UserProfiles.SingleOrDefault(up => up.Id == currentUserId);
+        UserProfile currentUser = _dbContext.UserProfiles
+            .Include(up => up.IdentityUser)
+            .SingleOrDefault(up => up.Id == currentUserId);
+        IdentityRole adminRole = _dbContext
+            .Roles
+            .SingleOrDefault(r => r.Name == "Admin");
+        IdentityUserRole<string> currentUserRole = _dbContext
+            .UserRoles
+            .SingleOrDefault(ur => ur.RoleId == adminRole.Id && ur.UserId == currentUser.IdentityUserId);
 
         if (currentUser == null)
         {
             return NotFound("Current User does not exist");
         }
         //Checks if initiator has the role admin
-        if (!currentUser.Roles.Contains("Admin"))
+        if (currentUserRole == null)
         {
             return Forbid();
         }
@@ -124,7 +133,7 @@ public class UserProfileController : ControllerBase
         _dbContext.AdminActions.Add(action);
         _dbContext.SaveChanges();
 
-        return Ok(new { message = "Demotion initiated, awaiting second admin approval"});
+        return Ok(new { message = "Demotion initiated, awaiting second admin approval", action = new AdminActionDTO(action)});
 
     }
 
@@ -145,12 +154,20 @@ public class UserProfileController : ControllerBase
         //find the voting admin and makes sure they exist, and that they are an admin
         UserProfile votingAdmin = _dbContext.UserProfiles.SingleOrDefault(up => up.Id == currentUserId);
 
+        IdentityRole adminRole = _dbContext
+        .Roles
+        .SingleOrDefault(r => r.Name == "Admin");
+        
+        IdentityUserRole<string> currentUserRole = _dbContext
+        .UserRoles
+        .SingleOrDefault(ur => ur.RoleId == adminRole.Id && ur.UserId == votingAdmin.IdentityUserId);
+
         if (votingAdmin == null)
         {
             return NotFound("That Admin does not exist");
         }
 
-        if (!votingAdmin.Roles.Contains("Admin"))
+        if (currentUserRole == null)
         {
             return Forbid();
         }
@@ -195,7 +212,24 @@ public class UserProfileController : ControllerBase
         } 
         
         _dbContext.SaveChanges();
-        return Ok(new {message = "Vote Recorded", action.Status});
+        return Ok(new {message = "Vote Recorded", action = new AdminActionDTO(action)});
+    }
+
+    [HttpGet("/pending/{userId}")]
+    [Authorize(Roles = "Admin")]
+    public IActionResult PendingActions(int userId)
+    {
+        AdminAction pendingActions = _dbContext
+        .AdminActions
+        .Include(a => a.Votes)
+        .FirstOrDefault(a => a.TargetUserId == userId && a.Status == ActionStatus.Pending);
+
+        if (pendingActions == null)
+        {
+            return NotFound("Current User has no pending actions");
+        }
+
+        return Ok(new AdminActionDTO(pendingActions));
     }
     
     [Authorize]

--- a/Controllers/UserProfileController.cs
+++ b/Controllers/UserProfileController.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -72,19 +74,130 @@ public class UserProfileController : ControllerBase
 
     [HttpPost("demote/{id}")]
     [Authorize(Roles = "Admin")]
-    public IActionResult Demote(string id)
+    public IActionResult InitializeDemotion(string id, [FromQuery, Required] int currentUserId)
     {
-        IdentityRole role = _dbContext.Roles.SingleOrDefault(r => r.Name == "Admin");
 
-        IdentityUserRole<string> userRole = _dbContext.UserRoles.SingleOrDefault(ur =>
-            ur.RoleId == role.Id && ur.UserId == id
+        UserProfile currentUser = _dbContext.UserProfiles.SingleOrDefault(up => up.Id == currentUserId);
+
+        if (currentUser == null)
+        {
+            return NotFound("Current User does not exist");
+        }
+        //Checks if initiator has the role admin
+        if (!currentUser.Roles.Contains("Admin"))
+        {
+            return Forbid();
+        }
+
+        //Finds the user to demote and checks if it exists or not
+        UserProfile userToDemote = _dbContext.UserProfiles.SingleOrDefault(up => up.IdentityUserId == id);
+
+        if (userToDemote == null)
+        {
+            return NotFound("That user does not exist");
+        }    
+        
+        //Checks to see if that Action already exists
+        AdminAction existingAction = _dbContext.AdminActions
+            .FirstOrDefault(a => a.TargetUserId == userToDemote.Id && a.Type == ActionType.Demote && a.Status == ActionStatus.Pending);
+
+        if (existingAction != null)
+        {
+            return BadRequest("A demotion request for this user is already pending.");
+        }
+
+        //Create a new demote action
+        AdminAction action = new AdminAction 
+        {
+            Type = ActionType.Demote,
+            TargetUserId = userToDemote.Id,
+            InitiatorId = currentUserId
+        };
+
+        //Adds the vote to demote
+        action.Votes.Add(new AdminActionVote 
+        {
+            AdminId = currentUserId,
+            IsApproved = true
+        });
+
+        _dbContext.AdminActions.Add(action);
+        _dbContext.SaveChanges();
+
+        return Ok(new { message = "Demotion initiated, awaiting second admin approval"});
+
+    }
+
+    [HttpPost("demote/vote/{actionId}")]
+    [Authorize (Roles = "Admin")]
+    public IActionResult DemoteVote(int actionId, [FromQuery, Required] int currentUserId)
+    {
+        //finds the current action being voted on
+        AdminAction action = _dbContext.AdminActions
+            .Include(a => a.Votes)
+            .SingleOrDefault(a => a.Id == actionId);
+
+        if (action == null)
+        {
+            return NotFound("That action does not exist");
+        }
+
+        //find the voting admin and makes sure they exist, and that they are an admin
+        UserProfile votingAdmin = _dbContext.UserProfiles.SingleOrDefault(up => up.Id == currentUserId);
+
+        if (votingAdmin == null)
+        {
+            return NotFound("That Admin does not exist");
+        }
+
+        if (!votingAdmin.Roles.Contains("Admin"))
+        {
+            return Forbid();
+        }
+        
+        //Check to ensure voting admin hasn't already voted
+        if (action.Votes.Any(v => v.AdminId == currentUserId))
+        {
+            return BadRequest("You have already voted on this action.");
+        }
+
+        action.Votes.Add( new AdminActionVote
+        {
+            AdminId = currentUserId,
+            IsApproved = true
+        });
+
+        //Finds the user that is being demoted
+        UserProfile userToDemote = _dbContext.UserProfiles.SingleOrDefault(up => up.Id == action.TargetUserId);
+
+        if (userToDemote == null)
+        {
+            return NotFound("User to demote doesn't exist.");
+        }
+
+        //Check if 2 votes have been cast
+        if (action.Votes.Count >= 2)
+        {
+            //If action has 2 votes sets status of action to approved
+            action.Status = ActionStatus.Approved;
+
+            //Then finds the role and removes the relationship between admin role and admin user
+            IdentityRole role = _dbContext.Roles.SingleOrDefault(r => r.Name == "Admin");
+
+
+            IdentityUserRole<string> userRole = _dbContext.UserRoles.SingleOrDefault(ur =>
+            ur.RoleId == role.Id && ur.UserId == userToDemote.IdentityUserId
         );
 
         _dbContext.UserRoles.Remove(userRole);
         _dbContext.SaveChanges();
         return NoContent();
+        } 
+        
+        _dbContext.SaveChanges();
+        return Ok(new {message = "Vote Recorded", action.Status});
     }
-
+    
     [Authorize]
     [HttpGet("{id}")]
     public IActionResult GetById(int id)

--- a/Controllers/UserProfileController.cs
+++ b/Controllers/UserProfileController.cs
@@ -226,7 +226,7 @@ public class UserProfileController : ControllerBase
         return Ok(new {message = "Vote Recorded", action = new AdminActionDTO(action)});
     }
 
-    [HttpGet("/pending/{userId}")]
+    [HttpGet("pending/{userId}")]
     [Authorize(Roles = "Admin")]
     public IActionResult PendingActions(int userId)
     {

--- a/Models/AdminAction.cs
+++ b/Models/AdminAction.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Tabloid.Models;
+
+public class AdminAction 
+{
+    public int Id { get; set; }
+    public ActionType Type { get; set; }
+    public int TargetUserId { get; set; }
+    [ForeignKey("TargetUserId")]
+    public UserProfile TargetUser { get; set; }
+    public int InitiatorId { get; set; }
+    [ForeignKey("InitiatorId")]
+    public UserProfile Initiator { get; set; }
+    public List<AdminActionVote> Votes { get; set; } = new();
+    public DateTime CreatedAt { get; set; } = DateTime.Now;
+    public ActionStatus Status { get; set; } = ActionStatus.Pending;
+}
+
+public class AdminActionVote
+{
+    public int Id { get; set; }
+    public int AdminActionId { get; set; }
+    public AdminAction AdminAction { get; set; }
+    public int AdminId { get; set; }
+    [ForeignKey("AdminId")]
+    public UserProfile Admin { get; set; }
+    public bool IsApproved { get; set; }
+    public DateTime VotedAt { get; set; } = DateTime.Now;
+}
+
+public enum ActionType {Promote, Demote }
+public enum ActionStatus { Pending, Approved, Rejected}

--- a/Models/DTOs/AdminActionDTO.cs
+++ b/Models/DTOs/AdminActionDTO.cs
@@ -1,0 +1,34 @@
+namespace Tabloid.Models.DTOs;
+
+public class AdminActionDTO
+{
+    public int Id { get; set; }
+    public string Type { get; set; }
+    public string Status { get; set ;}
+    public int TargetUserId { get; set; }
+    public int InitiatorId { get; set; }
+    public List<AdminActionVoteDTO> Votes { get; set; }
+
+
+    public AdminActionDTO(AdminAction action)
+    {
+        Id = action.Id;
+        Type = action.Type.ToString();
+        Status = action.Status.ToString();
+        TargetUserId = action.TargetUserId;
+        InitiatorId = action.InitiatorId;
+        Votes = action.Votes.Select(v => new AdminActionVoteDTO(v)).ToList();
+    }
+}
+
+public class AdminActionVoteDTO 
+{
+    public int AdminId { get; set; }
+    public bool IsApproved { get; set ;}
+
+    public AdminActionVoteDTO(AdminActionVote vote)
+    {
+        AdminId = vote.AdminId;
+        IsApproved = vote.IsApproved;
+    }
+}

--- a/TabloidDbContext.cs
+++ b/TabloidDbContext.cs
@@ -19,6 +19,8 @@ public class TabloidDbContext : IdentityDbContext<IdentityUser>
     public DbSet<PostTag> PostTags { get; set; }
     public DbSet<Comment> Comments { get; set; }
     public DbSet<Subscription> Subscriptions { get; set; }
+    public DbSet<AdminAction> AdminActions { get; set; }
+    public DbSet<AdminActionVote> AdminActionVotes { get; set ;}
 
     public TabloidDbContext(DbContextOptions<TabloidDbContext> context, IConfiguration config)
         : base(context)


### PR DESCRIPTION
Related Issue:

Changes:
Created models and dtos for AdminAction and AdminActionVote
Created an endpoint to initialize an admin action
Created an endpoint to cast a vote on a created AdminAction
Created an endpoint to Get pending actions on a specific user
Added managers to for each new endpoint
Changed handleUpdateUserRole handler function as well as renderButtons function in UserProfileDetails component with the new logic  
Readme Info:

- [ ] required packages (new)
- [ ] API instructions

Any other Testing Steps:
Be logged in as an admin, and view the user profile details of another admin.
Press the "Demote" button.
Log out, and log back in as another admin
Navigate to the same user you wish to demote, and click the "Vote to Demote" button
closes NSS-Day-Cohort-73/Tabloid-client-uakfwy#45
